### PR TITLE
Development proxypass resolver fix

### DIFF
--- a/build-and-run-docker.sh
+++ b/build-and-run-docker.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 docker build -t datahub-ui:latest .
-docker run --rm -d -p 8080:80 -e PROXY_PASS_URL=http://localhost:3006/api -e PROXY_PASS_APICC_URL=http://localhost:3003/apicc datahub-ui:latest
+docker run --rm -d -p 8080:80 -e PROXY_PASS_WEBAPI=http://localhost:3006/api -e PROXY_PASS_APICC=http://localhost:3003/apicc datahub-ui:latest

--- a/build-and-run-docker.sh
+++ b/build-and-run-docker.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 docker build -t datahub-ui:latest .
-docker run --rm -d -p 8080:80 -e PROXY_PASS_WEBAPI=http://localhost:3006/api -e PROXY_PASS_APICC=http://localhost:3003/apicc datahub-ui:latest
+docker run --rm -d -p 8080:80 -e PROXY_PASS_WEBAPI="proxy_pass http://localhost:3006" -e PROXY_PASS_APICC="proxy_pass http://localhost:3003" datahub-ui:latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-envsubst '${PROXY_PASS_URL},${PROXY_PASS_APICC_URL}' < /etc/nginx/nginx.template.conf > /etc/nginx/nginx.conf
+envsubst '${PROXY_PASS_WEBAPI},${PROXY_PASS_APICC}' < /etc/nginx/nginx.template.conf > /etc/nginx/nginx.conf
 nginx -g 'daemon off;'

--- a/nginx.template.conf
+++ b/nginx.template.conf
@@ -31,10 +31,16 @@ http {
            try_files $uri $uri/ @rewrites;
         }
         location /api {
-               proxy_pass ${PROXY_PASS_URL};
+               ## Local example using localhost:
+               # proxy_pass http://localhost:3000
+
+               ## Deployed example using DNS resolver:
+               # resolver 10.0.0.2 valid=10s; set $backend "http://example-loadbalancer.amazonaws.com:3000"; proxy_pass $backend;
+               
+               ${PROXY_PASS_WEBAPI}
         }
         location /apicc {
-               proxy_pass ${PROXY_PASS_APICC_URL};
+               ${PROXY_PASS_APICC}
         }
 
         error_page   500 502 503 504  /50x.html;

--- a/nginx.template.conf
+++ b/nginx.template.conf
@@ -31,6 +31,7 @@ http {
            try_files $uri $uri/ @rewrites;
         }
         location /api {
+
                ## Local example using localhost:
                # proxy_pass http://localhost:3000
 


### PR DESCRIPTION
### Overview

This changes the names of the proxy pass env vars and changes the proxy pass config to requiring the entire configuration passed in. This allows users to fix the nginx issue [discussed here](https://serverfault.com/questions/240476/how-to-force-nginx-to-resolve-dns-of-a-dynamic-hostname-everytime-when-doing-p).

By renaming the variables and not reusing them, I am able to provide both variables in the Fargate task definition which allows for an automatic, seamless transition.

### Changes
- Renamed environment variable `PROXY_PASS_URL` to `PROXY_PASS_WEBAPI`
- Renamed environment variable `PROXY_PASS_APICC_URL` to `PROXY_PASS_APICC`
- Replaced variables in the docker script
- Replaced variables in the nginx template
- Added a simple usage description in the nginx template